### PR TITLE
Bump bourbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Include bourbon in an ember-cli app.
 
-When the addon is installed, it will add bourbon 3.2.1 as
-a bower dependency. (The newer bourbon 4.0.x is not compatible with node-sass at the time of
-this writing).
+When the addon is installed, it will add bourbon as a bower dependency.
 
 ## Dependencies
 

--- a/blueprints/ember-cli-bourbon/index.js
+++ b/blueprints/ember-cli-bourbon/index.js
@@ -6,6 +6,6 @@ module.exports = {
   },
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('bourbon', '3.2.1');
+    return this.addBowerPackageToProject('bourbon', '4.2.1');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "qunit": "~1.15.0"
   },
   "devDependencies": {
-    "bourbon": "~3.2.1"
+    "bourbon": "~4.2.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
   treeForStyles: function() {
-    var bourbonPath = path.join(this.app.bowerDirectory, 'bourbon', 'dist');
+    var bourbonPath = path.join(this.app.bowerDirectory, 'bourbon', 'app');
     var bourbonTree = this.pickFiles(this.treeGenerator(bourbonPath), {
-      srcDir: '/',
+      srcDir: '/assets/stylesheets',
       destDir: '/app/styles'
     });
     return bourbonTree;


### PR DESCRIPTION
* Remove version caveats from README.
* Point at new asset path (dist folder was removed in this commit:
  https://github.com/thoughtbot/bourbon/commit/33959303edde7c1b98cf18496c7e68a4f56b90ed)

I tested locally to ensure this is working by using `npm link` to install within a cleanish ember app.