### PR TITLE
These fixes allow ember-cli-bourbon to be used as a Nested addon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ module.exports = {
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },
+
   treeForStyles: function() {
-    var bourbonPath = path.join(this.app.bowerDirectory, 'bourbon', 'app');
+    var bourbonPath = path.join(this.project.bowerDirectory, 'bourbon', 'app');
     var bourbonTree = new Funnel(this.treeGenerator(bourbonPath), {
       srcDir: '/assets/stylesheets',
       destDir: '/app/styles'


### PR DESCRIPTION
check out https://github.com/ember-cli/ember-cli/issues/3718 for a detailed error description for what happens currently without this patch.